### PR TITLE
Fix logout prop docs

### DIFF
--- a/src/components/CustomNavbar.tsx
+++ b/src/components/CustomNavbar.tsx
@@ -13,12 +13,12 @@ import { NavbarProps } from '../interfaces/interface.navbar';
  * and user information (name, role, avatar) if a user is logged in.
  * Provides a logout functionality.
  *
- * @param {NavbarProps} props - Props for the Navbar, currently includes `environment`, `urlUser`, and `logoutEndpointUrl`.
+ * @param {NavbarProps} props - Props for the Navbar, currently includes `environment`, `urlUser`, and `urlLogout`.
  * @returns {React.ReactElement} The rendered Navbar component.
  *
  * @example
  * // Navbar with user session fetching from a custom endpoint
- * <CustomNavbar environment="development" urlUser="/auth/session" logoutEndpointUrl="/auth/logout" />
+ * <CustomNavbar environment="development" urlUser="/auth/session" urlLogout="/auth/logout" />
  *
  * // Navbar without user session fetching (e.g., for public pages)
  * <CustomNavbar environment="development" />

--- a/src/hooks/useUserSession.tsx
+++ b/src/hooks/useUserSession.tsx
@@ -44,7 +44,7 @@ export interface UseUserSessionProps {
  * // With custom session and logout URLs
  * const { user, logout, isLoading, error } = useUserSession({
  *   sessionEndpointUrl: '/auth/session',
- *   logoutEndpointUrl: '/auth/logout'
+ *   urlLogout: '/auth/logout'
  * });
  *
  * // Without session fetching (e.g., for public pages)


### PR DESCRIPTION
## Summary
- fix JSDoc in `CustomNavbar` to reference `urlLogout`
- update `useUserSession` example to use `urlLogout`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685242a7d414832aaa6294d899598ea3