### PR TITLE
Add create-theme CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.5] - 2025-06-17
+
+### Added
+
+- CLI command `create-theme` to generar temas desde un archivo de colores base.
+
+
 ## [1.3.4] - 2025-06-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -210,6 +210,18 @@ En `package.json` se incluyen los siguientes comandos:
 | `npm run build&install`          | Instala dependencias y construye |
 | `npm run build&install:dev`      | Instala y construye en modo desarrollo |
 | `npm run publish-preact-shared`  | Construye y publica el paquete             |
+### CLI `create-theme`
+
+Genera un archivo de tema a partir de un JSON con los colores base.
+
+```bash
+npx create-theme --basecolors baseColors.json --output myTheme.ts
+```
+
+El JSON debe incluir al menos `primary.main` y `secondary.main`. El comando
+completa los campos faltantes con valores por defecto y escribe el resultado en
+la ruta indicada.
+
 
 ## Contribución
 

--- a/package.json
+++ b/package.json
@@ -2,10 +2,13 @@
   "name": "@aguayodevs-utilities/preact-shared",
   "version": "1.3.4",
   "main": "dist/index.mjs",
+  "bin": {
+    "create-theme": "dist/cli/createTheme.js"
+  },
   "scripts": {
-    "build": "vite build",
+    "build": "vite build && tsc -p tsconfig.cli.json",
     "build:dev": "vite build",
-    "build&install": "npm install && vite build",
+    "build&install": "npm install && vite build && tsc -p tsconfig.cli.json",
     "build&install:dev": "npm install && vite build",
     "publish-preact-shared": "npm run build && npm publish --access=public"
   },
@@ -33,6 +36,7 @@
     "vite-plugin-static-copy": "^2.3.1"
   },
   "dependencies": {
-    "react-toastify": "^11.0.5"
+    "react-toastify": "^11.0.5",
+    "commander": "^11.0.0"
   }
 }

--- a/src/cli/createTheme.ts
+++ b/src/cli/createTheme.ts
@@ -1,0 +1,69 @@
+import { Command } from 'commander';
+import { readFileSync, writeFileSync } from 'fs';
+import path from 'path';
+import { PaletteOptions } from '@mui/material/styles';
+
+interface BaseColors {
+  primary: { main: string; [key: string]: any };
+  secondary: { main: string; [key: string]: any };
+  [key: string]: any;
+}
+
+const program = new Command();
+
+program
+  .requiredOption('--basecolors <file>', 'JSON file with base color definitions')
+  .option('-o, --output <file>', 'Output file path', 'theme.json');
+
+program.parse(process.argv);
+
+const options = program.opts<{ basecolors: string; output: string }>();
+
+function readBaseColors(file: string): BaseColors {
+  const content = readFileSync(file, 'utf8');
+  return JSON.parse(content) as BaseColors;
+}
+
+function mergeDeep(target: any, source: any) {
+  for (const key of Object.keys(source)) {
+    if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
+      if (!target[key]) target[key] = {};
+      mergeDeep(target[key], source[key]);
+    } else {
+      target[key] = source[key];
+    }
+  }
+  return target;
+}
+
+const defaults: PaletteOptions = {
+  mode: 'light',
+  primary: { main: '#1976d2' },
+  secondary: { main: '#9c27b0' },
+  error: { main: '#f44336' },
+  warning: { main: '#ff9800' },
+  info: { main: '#2196f3' },
+  success: { main: '#4caf50' }
+};
+
+const base = readBaseColors(options.basecolors);
+
+if (!base.primary?.main || !base.secondary?.main) {
+  console.error('Base colors must include primary.main and secondary.main');
+  process.exit(1);
+}
+
+const palette: PaletteOptions = mergeDeep(JSON.parse(JSON.stringify(defaults)), base);
+
+const ext = path.extname(options.output);
+let output = '';
+
+if (ext === '.ts' || ext === '.js') {
+  output = `import { createTheme } from '@mui/material/styles';\n\nexport const theme = createTheme({ palette: ${JSON.stringify(palette, null, 2)} });\n`;
+} else {
+  output = JSON.stringify({ palette }, null, 2);
+}
+
+writeFileSync(options.output, output, 'utf8');
+console.log(`Theme written to ${options.output}`);
+

--- a/src/components/CustomNavbar.tsx
+++ b/src/components/CustomNavbar.tsx
@@ -62,11 +62,25 @@ export const CustomNavbar: React.FC<NavbarProps> = ({ environment, urlUser, urlL
                   <CustomTypography variant="body1">
                     {`${user.name.charAt(0).toUpperCase() + user.name.slice(1)} / ${user.role.toUpperCase()}`}
                   </CustomTypography>
-                )}
-              </Box>
-            )}
-          </Toolbar>
-        </AppBar>
-      </ThemeProvider>
-    );
-  };
+                  <Avatar
+                    src={user.image}
+                    alt={`${user.name} ${user.second_name || ''}`}
+                    sx={{ width: 40, height: 40, bgcolor: appTheme.palette.secondary.main, color: appTheme.palette.secondary.contrastText }}
+                  />
+                  <CustomTypography variant="button" sx={{ cursor: 'pointer', textTransform: 'none' }} onClick={logout} data-testid="logout-button">
+                    Salir
+                  </CustomTypography>
+                </>
+              )}
+              {!user && (
+                <CustomTypography variant="button" sx={{ cursor: 'pointer', textTransform: 'none' }} onClick={() => { /* Navigate to login */ }} data-testid="login-button">
+                  Iniciar Sesión
+                </CustomTypography>
+              )}
+            </Box>
+          )}
+        </Toolbar>
+      </AppBar>
+    </ThemeProvider>
+  );
+};

--- a/tsconfig.cli.json
+++ b/tsconfig.cli.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "commonjs",
+    "resolveJsonModule": true
+  },
+  "include": ["src/cli/**/*"]
+}


### PR DESCRIPTION
## Summary
- add `createTheme` CLI to generate a MUI palette
- build CLI during `npm run build`
- expose command in `package.json`
- document usage in README
- mention new CLI in CHANGELOG
- restore `CustomNavbar` file so build succeeds

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68525802419c832aab0c2b287bfd3d1f