### PR TITLE
Add customizable theme context

### DIFF
--- a/src/components/CustomBreadcrumb.tsx
+++ b/src/components/CustomBreadcrumb.tsx
@@ -2,8 +2,7 @@ import { FunctionComponent } from 'preact';
 import { Breadcrumbs, Link } from '@mui/material'; // Typography removed as CustomTypography is used
 import HomeIcon from '@mui/icons-material/Home';
 import { useBreadcrumbs } from '../hooks/useBreadcrumbs';
-import { appDeliveryTheme } from '../styles/CustomTheme'; // Updated path
-import { ThemeProvider } from '@mui/material/styles';
+import { CustomThemeProvider, useCustomTheme } from '../styles/CustomThemeContext';
 import { CustomTypography } from './CustomTypography';
 
 /**
@@ -20,9 +19,10 @@ import { CustomTypography } from './CustomTypography';
  */
 export const CustomBreadcrumb = ({ urlLabels }: { urlLabels?: string }) => {
   const [crumbs, go] = useBreadcrumbs(urlLabels);
+  const theme = useCustomTheme();
   
   return (
-    <ThemeProvider theme={appDeliveryTheme}>
+    <CustomThemeProvider theme={theme}>
       <Breadcrumbs aria-label="breadcrumb" sx={{ mb: 2, fontSize: '24px' }}>
         <Link
           underline="hover"
@@ -51,6 +51,6 @@ export const CustomBreadcrumb = ({ urlLabels }: { urlLabels?: string }) => {
           )
         )}
       </Breadcrumbs>
-    </ThemeProvider>
+    </CustomThemeProvider>
   );
 };

--- a/src/components/CustomButton.tsx
+++ b/src/components/CustomButton.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { Button, ButtonProps as MuiButtonProps } from "@mui/material"; // Renamed to avoid conflict
 import { CustomTypography } from "./CustomTypography";
-import { appDeliveryTheme } from "../styles/CustomTheme"; // Updated path
-import { ThemeProvider } from "@mui/material/styles";
+import { CustomThemeProvider, useCustomTheme } from "../styles/CustomThemeContext";
 
 /**
  * @interface CustomButtonProps
@@ -24,13 +23,14 @@ export interface CustomButtonProps extends MuiButtonProps {
  * @returns {React.ReactElement} The rendered button component.
  */
 const CustomButtonComponent: React.FC<CustomButtonProps> = (props) => {
+    const theme = useCustomTheme();
     // Determine button colors based on props and theme
     // Valid MUI Button color props are 'inherit', 'primary', 'secondary', 'success', 'error', 'info', 'warning'
     const isPaletteColor = props.color && ['primary', 'secondary', 'success', 'error', 'info', 'warning'].includes(props.color);
 
-    const backgroundColor = isPaletteColor ? `${props.color}.main` : (props.color === 'inherit' ? undefined : appDeliveryTheme.palette.primary.main);
-    const textColor = isPaletteColor ? `${props.color}.contrastText` : (props.color === 'inherit' ? undefined : appDeliveryTheme.palette.primary.contrastText);
-    const hoverBackgroundColor = isPaletteColor ? `${props.color}.dark` : (props.color === 'inherit' ? undefined : appDeliveryTheme.palette.primary.dark);
+    const backgroundColor = isPaletteColor ? `${props.color}.main` : (props.color === 'inherit' ? undefined : theme.palette.primary.main);
+    const textColor = isPaletteColor ? `${props.color}.contrastText` : (props.color === 'inherit' ? undefined : theme.palette.primary.contrastText);
+    const hoverBackgroundColor = isPaletteColor ? `${props.color}.dark` : (props.color === 'inherit' ? undefined : theme.palette.primary.dark);
 
     return (
         <Button
@@ -66,8 +66,8 @@ const CustomButtonComponent: React.FC<CustomButtonProps> = (props) => {
  * </CustomButton>
  */
 export const CustomButton: React.FC<CustomButtonProps> = (props) => (
-    <ThemeProvider theme={appDeliveryTheme}>
+    <CustomThemeProvider>
         <CustomButtonComponent {...props} />
-    </ThemeProvider>
+    </CustomThemeProvider>
 );
 

--- a/src/components/CustomError.tsx
+++ b/src/components/CustomError.tsx
@@ -4,8 +4,7 @@ import {
   List, ListItemText
 } from '@mui/material'; // Typography and Button removed
 import SentimentVeryDissatisfiedIcon from '@mui/icons-material/SentimentVeryDissatisfied';
-import { ThemeProvider } from '@mui/material/styles';
-import { appDeliveryTheme } from '../styles/CustomTheme'; // Updated path
+import { CustomThemeProvider, useCustomTheme } from '../styles/CustomThemeContext';
 import { CustomTypography } from './CustomTypography';
 import { CustomButton } from './CustomButton'; // Using CustomButton
 
@@ -50,8 +49,10 @@ export const ErrorState: React.FC<ErrorStateProps> = ({
   actionLabel,
   onAction,
   children
-}) => (
-  <ThemeProvider theme={appDeliveryTheme}>
+}) => {
+  const theme = useCustomTheme();
+  return (
+  <CustomThemeProvider theme={theme}>
     <Box
       component={Paper}
       elevation={0} // Consider a slight elevation for better visual separation if needed
@@ -118,5 +119,6 @@ export const ErrorState: React.FC<ErrorStateProps> = ({
         )}
       </Stack>
     </Box>
-  </ThemeProvider>
-);
+  </CustomThemeProvider>
+  );
+};

--- a/src/components/CustomImageComboBox.tsx
+++ b/src/components/CustomImageComboBox.tsx
@@ -9,8 +9,7 @@ import {
   Theme, // Import Theme for type hinting
 } from '@mui/material'; // Typography removed
 import type { ImageComboBoxOption, ImageComboBoxProps } from '../interfaces/interface.imageComboBox';
-import { appDeliveryTheme } from '../styles/CustomTheme'; // Updated path
-import { ThemeProvider, useTheme } from '@mui/material/styles';
+import { CustomThemeProvider, useCustomTheme } from '../styles/CustomThemeContext';
 import { CustomTypography } from './CustomTypography';
 
 /**
@@ -45,13 +44,13 @@ export const CustomImageComboBox: React.FC<ImageComboBoxProps> = ({
   disabled = false,
 }) => {
   const selected = useMemo(
-    () => options.find((o) => o.value === value) || undefined, // Changed null to undefined
+    () => options.find((o) => o.value === value) || undefined,
     [options, value]
   );
-  const currentTheme = useTheme(); // Renamed to avoid conflict with Theme type
+  const theme = useCustomTheme();
 
   return (
-    <ThemeProvider theme={appDeliveryTheme}>
+    <CustomThemeProvider theme={theme}>
       <Autocomplete
         options={options}
         getOptionLabel={(option) => option.label} // Ensure option is typed if possible
@@ -64,7 +63,7 @@ export const CustomImageComboBox: React.FC<ImageComboBoxProps> = ({
         noOptionsText="Sin resultados"
         sx={{
           width: '100%',
-          '& .MuiOutlinedInput-root': { backgroundColor: appDeliveryTheme.palette.background.paper }, // Use theme variable
+          '& .MuiOutlinedInput-root': { backgroundColor: theme.palette.background.paper },
         }}
         renderInput={(params) => {
           const { InputProps, ...restParams } = params; // Destructure to avoid passing InputProps directly if modified
@@ -88,20 +87,19 @@ export const CustomImageComboBox: React.FC<ImageComboBoxProps> = ({
               disabled={disabled}
               // color="primary" // color prop on TextField is for focus ring, not text/bg
               sx={{
-                // backgroundColor: appDeliveryTheme.palette.background.paper, // Moved to Autocomplete root for consistency
                 '& input::placeholder': {
-                  color: appDeliveryTheme.palette.text.secondary, // Use theme for placeholder color
+                  color: theme.palette.text.secondary,
                   opacity: 1,
                 },
                 '& .MuiOutlinedInput-notchedOutline': {
-                  borderColor: appDeliveryTheme.palette.divider, // Use theme for border color
+                  borderColor: theme.palette.divider,
                 },
                 '&:hover .MuiOutlinedInput-notchedOutline': {
-                  borderColor: appDeliveryTheme.palette.primary.main, // Use theme for hover border
+                  borderColor: theme.palette.primary.main,
                 },
                 '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
-                  borderColor: appDeliveryTheme.palette.primary.main, // Use theme for focused border
-                  borderWidth: '1px', // Ensure focus ring is visible
+                  borderColor: theme.palette.primary.main,
+                  borderWidth: '1px',
                 },
               }}
               InputProps={{
@@ -155,6 +153,6 @@ export const CustomImageComboBox: React.FC<ImageComboBoxProps> = ({
           </Box>
         )}
       />
-    </ThemeProvider>
+    </CustomThemeProvider>
   );
 };

--- a/src/components/CustomInput.tsx
+++ b/src/components/CustomInput.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { styled, ThemeProvider } from '@mui/material/styles'; // Combined imports, removed useTheme
-import { TextField, TextFieldProps as MuiTextFieldProps, Theme } from '@mui/material'; // Renamed to avoid conflict
-import { appDeliveryTheme } from '../styles/CustomTheme'; // Updated path
+import { styled } from '@mui/material/styles';
+import { TextField, TextFieldProps as MuiTextFieldProps, Theme } from '@mui/material';
+import { CustomThemeProvider, useCustomTheme } from '../styles/CustomThemeContext';
 // CustomTypography is removed as TextField itself handles text, and children are not typical for TextField
 
 /**
@@ -53,7 +53,7 @@ const StyledTextField = styled(TextField)<CustomInputProps>(({ theme }) => ({
  * @component CustomInput
  * @description A customized TextField component using Material-UI's TextField and styled-components.
  * It provides a default styling that can be overridden via props.
- * The component is wrapped with a ThemeProvider using `appDeliveryTheme`.
+ * The component is wrapped with a CustomThemeProvider using the current theme.
  *
  * @param {CustomInputProps} props - The props for the TextField component.
  * @returns {React.ReactElement} The rendered custom input field.
@@ -67,14 +67,13 @@ const StyledTextField = styled(TextField)<CustomInputProps>(({ theme }) => ({
  * />
  */
 export const CustomInput: React.FC<CustomInputProps> = (props) => {
-  // The ThemeProvider might be redundant if appDeliveryTheme is globally provided at the app's root.
-  // However, keeping it here ensures this component is self-contained with its specific theme context if needed.
+  const theme = useCustomTheme();
   
   // Apply defaults before passing to StyledTextField
   const { variant = 'outlined', fullWidth = true, ...restProps } = props;
 
   return (
-    <ThemeProvider theme={appDeliveryTheme}>
+    <CustomThemeProvider theme={theme}>
       <StyledTextField
         variant={variant}
         fullWidth={fullWidth}
@@ -82,6 +81,6 @@ export const CustomInput: React.FC<CustomInputProps> = (props) => {
         // Children are not typically passed to TextField. If they were meant for a label or helper text,
         // those should be passed via `label` or `helperText` props respectively.
       />
-    </ThemeProvider>
+    </CustomThemeProvider>
   );
 };

--- a/src/components/CustomModal.tsx
+++ b/src/components/CustomModal.tsx
@@ -2,14 +2,14 @@ import React from 'react';
   import { FunctionComponent, ComponentChildren } from 'preact';
   import Box from '@mui/material/Box';
   import Modal, { ModalProps as MuiModalProps } from '@mui/material/Modal'; // Import ModalProps
-  import { appDeliveryTheme } from '../styles/CustomTheme'; // Updated path
-  import { ThemeProvider } from '@mui/material/styles';
+import { CustomThemeProvider, useCustomTheme } from '../styles/CustomThemeContext';
+import { Theme } from '@mui/material/styles';
   import { CustomTypography } from './CustomTypography';
   import CloseIcon from '@mui/icons-material/Close'; // For a close button
   import { IconButton } from '@mui/material'; // For the close button
   
   // It's better to define styles using the theme for consistency
-  const modalStyle = (theme: typeof appDeliveryTheme) => ({ // Type theme for better intellisense
+  const modalStyle = (theme: Theme) => ({
     position: 'absolute' as 'absolute', // Explicitly type position
     top: '50%',
     left: '50%',
@@ -80,10 +80,12 @@ import React from 'react';
           setOpen(false);
       };
   
+      const theme = useCustomTheme();
+
       if (!open) return null;
-  
+
       return (
-          <ThemeProvider theme={appDeliveryTheme}>
+          <CustomThemeProvider theme={theme}>
               <Modal
                   open={open}
                   onClose={handleClose}
@@ -95,7 +97,7 @@ import React from 'react';
                   disableRestoreFocus={restMuiModalProps.disableRestoreFocus ?? false}
                   {...restMuiModalProps} // Pass other MUI Modal props
               >
-                  <Box sx={modalStyle(appDeliveryTheme)}>
+                  <Box sx={modalStyle(theme)}>
                       {showCloseButton && (
                           <IconButton
                               aria-label="close modal"
@@ -122,6 +124,6 @@ import React from 'react';
                       </Box>
                   </Box>
               </Modal>
-          </ThemeProvider>
+          </CustomThemeProvider>
       );
   };

--- a/src/components/CustomNavbar.tsx
+++ b/src/components/CustomNavbar.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { AppBar, Toolbar, Avatar, Box } from '@mui/material';
 import { useUserSession } from '../hooks/useUserSession';
-import { appTheme } from '../styles/CustomTheme';
-import { ThemeProvider } from '@mui/material/styles';
+import { CustomThemeProvider, useCustomTheme } from '../styles/CustomThemeContext';
 import { CustomTypography } from './CustomTypography';
 import { NavbarProps } from '../interfaces/interface.navbar';
 
@@ -25,6 +24,7 @@ import { NavbarProps } from '../interfaces/interface.navbar';
  */
 export const CustomNavbar: React.FC<NavbarProps> = ({ environment, urlUser, urlLogout }) => {
   const { user, logout, isLoading } = useUserSession({ sessionEndpointUrl: urlUser, urlLogout });
+  const theme = useCustomTheme();
 
   // Log environment if in development for debugging or specific features
   if (environment === 'development') {
@@ -32,12 +32,12 @@ export const CustomNavbar: React.FC<NavbarProps> = ({ environment, urlUser, urlL
   }
 
   return (
-    <ThemeProvider theme={appTheme}>
+    <CustomThemeProvider theme={theme}>
       <AppBar
         position="static"
         sx={{
-          bgcolor: appTheme.palette.background.paper,
-          boxShadow: appTheme.shadows[1],
+          bgcolor: theme.palette.background.paper,
+          boxShadow: theme.shadows[1],
         }}
       >
         <Toolbar>
@@ -62,11 +62,12 @@ export const CustomNavbar: React.FC<NavbarProps> = ({ environment, urlUser, urlL
                   <CustomTypography variant="body1">
                     {`${user.name.charAt(0).toUpperCase() + user.name.slice(1)} / ${user.role.toUpperCase()}`}
                   </CustomTypography>
-                )}
-              </Box>
-            )}
+                </>
+              )}
+            </Box>
+          )}
           </Toolbar>
         </AppBar>
-      </ThemeProvider>
-    );
-  };
+    </CustomThemeProvider>
+  );
+};

--- a/src/components/CustomTextArea.tsx
+++ b/src/components/CustomTextArea.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { styled, ThemeProvider } from '@mui/material/styles'; // Combined imports
-import { TextField, TextFieldProps as MuiTextFieldProps } from '@mui/material'; // Renamed to avoid conflict, removed Theme
-import { appDeliveryTheme } from '../styles/CustomTheme'; // Updated path
+import { styled } from '@mui/material/styles';
+import { TextField, TextFieldProps as MuiTextFieldProps } from '@mui/material';
+import { CustomThemeProvider, useCustomTheme } from '../styles/CustomThemeContext';
 
 /**
  * @type CustomTextareaProps
@@ -78,9 +78,10 @@ export const CustomTextarea: React.FC<CustomTextareaProps> = (props) => {
     // multiline is implicitly true for a textarea, but TextField needs it
     ...restProps
   } = props;
+  const theme = useCustomTheme();
 
   return (
-    <ThemeProvider theme={appDeliveryTheme}>
+    <CustomThemeProvider theme={theme}>
       <StyledTextarea
         variant={variant}
         fullWidth={fullWidth}
@@ -88,6 +89,6 @@ export const CustomTextarea: React.FC<CustomTextareaProps> = (props) => {
         minRows={minRows}
         {...restProps} // Pass all other props, including sx, maxRows, etc.
       />
-    </ThemeProvider>
+    </CustomThemeProvider>
   );
 };

--- a/src/components/CustomTypography.tsx
+++ b/src/components/CustomTypography.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import { FunctionComponent } from "preact";
-import { ThemeProvider, Typography, useTheme } from "@mui/material";
-import { TypographyProps } from "../interfaces/interface.Typography"; // This now extends MuiTypographyProps
-import { appDeliveryTheme } from "../styles/CustomTheme"; // Updated path
+import { Typography } from "@mui/material";
+import { TypographyProps } from "../interfaces/interface.Typography";
+import { CustomThemeProvider, useCustomTheme } from "../styles/CustomThemeContext";
 
 /**
  * @component CustomTypographyComponent
@@ -14,7 +14,7 @@ import { appDeliveryTheme } from "../styles/CustomTheme"; // Updated path
  * @returns {React.ReactElement} The rendered typography component.
  */
 const CustomTypographyComponent: FunctionComponent<TypographyProps> = (props) => {
-  const theme = useTheme(); // Access the theme for default values if needed
+  const theme = useCustomTheme();
 
   // Destructure custom props and pass the rest to MUI Typography
   const { strokeWidth, strokeColor, sx, ...restProps } = props;
@@ -50,9 +50,8 @@ const CustomTypographyComponent: FunctionComponent<TypographyProps> = (props) =>
 
 /**
  * @component CustomTypography
- * @description A wrapper component for CustomTypographyComponent that provides a ThemeProvider.
- * This ensures that the typography is rendered within the context of the application's theme
- * and allows usage of custom theme properties if defined in `appDeliveryTheme`.
+ * @description A wrapper component for CustomTypographyComponent that provides a CustomThemeProvider.
+ * This ensures that the typography is rendered within the context of the application's theme.
  *
  * @param {TypographyProps} props - The props for the typography component.
  * @returns {React.ReactElement} The themed typography component.
@@ -67,7 +66,7 @@ const CustomTypographyComponent: FunctionComponent<TypographyProps> = (props) =>
  * </CustomTypography>
  */
 export const CustomTypography: FunctionComponent<TypographyProps> = (props) => (
-    <ThemeProvider theme={appDeliveryTheme}>
+    <CustomThemeProvider>
         <CustomTypographyComponent {...props} />
-    </ThemeProvider>
+    </CustomThemeProvider>
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,8 @@ export * from './interfaces';
 export * from './helpers';
 
 // Styles
-export * from './styles'; // This re-exports from src/styles/index.ts (which should export appTheme)
+export * from './styles'; // Re-export themes and context
+export { CustomThemeProvider, useCustomTheme, CustomThemeContext } from './styles';
 
 // MUI re-exports are handled by peerDependencies, users should import directly from @mui/* packages.
 

--- a/src/styles/CustomThemeContext.tsx
+++ b/src/styles/CustomThemeContext.tsx
@@ -1,0 +1,25 @@
+import React, { createContext, useContext } from 'react';
+import { ThemeProvider as MUIThemeProvider, Theme } from '@mui/material/styles';
+import { appDeliveryTheme } from './CustomTheme';
+
+export const CustomThemeContext = createContext<Theme>(appDeliveryTheme);
+
+export const useCustomTheme = (): Theme => {
+  return useContext(CustomThemeContext) || appDeliveryTheme;
+};
+
+interface CustomThemeProviderProps {
+  theme?: Theme;
+  children: React.ReactNode;
+}
+
+export const CustomThemeProvider: React.FC<CustomThemeProviderProps> = ({ theme, children }) => {
+  const inheritedTheme = useCustomTheme();
+  const activeTheme = theme || inheritedTheme || appDeliveryTheme;
+
+  return (
+    <CustomThemeContext.Provider value={activeTheme}>
+      <MUIThemeProvider theme={activeTheme}>{children}</MUIThemeProvider>
+    </CustomThemeContext.Provider>
+  );
+};

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,8 +1,2 @@
-// CustomTheme.tsx is now located in src/styles/CustomTheme.tsx
 export * from './CustomTheme';
-
-// Regarding base.css, CSS files are typically imported directly where needed
-// (e.g., in a main application file or a top-level component like CustomLayout),
-// or via a main CSS file, not usually re-exported from a .ts module index like this.
-// If global styles from base.css are needed, consider importing it in src/index.ts or a similar entry point.
-// import '../assets/css/base.css'; // Example of direct import if needed globally
+export * from './CustomThemeContext';


### PR DESCRIPTION
## Summary
- introduce `CustomThemeContext` with provider and hook
- export context utilities
- update all components to use `CustomThemeProvider`
- fallback to `appDeliveryTheme` when no provider is used
- expose new utilities from package entrypoints

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685258003c8c832ab08cae4433f020c6